### PR TITLE
Fix docs build steps and add markdown link check

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The core of the AO.space, also known as the AO.space Server, consists of sofewar
 - Databases:
   - SQL Instance (Postgresql): It provides data storage and management for relational databases within the space.
   - NoSQL Instance (Redis): It offers data storage and management for non-relational databases within the space, as well as messaging capabilities.
-- Network client: It's part of implementation for transiting network from internet to NAT office or home netrok. It also helps to establish P2P connections with the AO.space client.
+- Network client: It's part of implementation for transiting network from internet to NAT office or home network. It also helps to establish P2P connections with the AO.space client.
 - Applications: They are divided into three types: front-end only, back-end only, and hybrid applications which contain front-end and back-end. They are mainly used to expand the functionality of the AO.space services and are the key elements of the AO.space ecosystem. These official or third-party applications can be accessed through the AO.space Space user domain from internet, such as Card/CalDAV services.
 
 ### Client-side

--- a/docs/cn/build-and-deploy.md
+++ b/docs/cn/build-and-deploy.md
@@ -50,7 +50,7 @@ docker build -t local/space-web:{tag} ./space-web
 docker build -t local/space-filepreview:{tag} ./space-filepreview
 docker build -t local/space-media-vod:{tag} ./space-media-vod
 docker build -t local/space-postgresql:{tag} ./space-postgresql
-docker build -t local/space-agent:{tag} ./space-postgresql
+docker build -t local/space-agent:{tag} ./space-agent
 docker build -t local/space-upgrade:{tag} ./space-upgrade
 
 ```
@@ -132,7 +132,7 @@ docker run -d --name aospace-all-in-one  \
 
 源码下载：
 
-可以使用[项目整体下载](xxx)下载的方式，也可以通过通过一下命令下载本模块的仓库：
+可以使用[项目整体下载](https://github.com/ao-space/ao.space)下载的方式，也可以通过通过一下命令下载本模块的仓库：
 
 - `git clone git@github.com:ao-space/client-android`
 
@@ -237,6 +237,4 @@ docker run -d --name aospace-all-in-one  \
 - Android 支持 5.0 及以上系统版本
 - iOS 支持 12.0 及以上系统版本
 
-请扫码安装客户端：
-
-![avatar](/assets/download_opensource.png)
+请访问[下载页面](https://ao.space/download)安装客户端。

--- a/docs/en/build-and-deploy.md
+++ b/docs/en/build-and-deploy.md
@@ -53,7 +53,7 @@ docker build -t local/space-web:{tag} ./space-web
 docker build -t local/space-filepreview:{tag} ./space-filepreview
 docker build -t local/space-media-vod:{tag} ./space-media-vod
 docker build -t local/space-postgresql:{tag} ./space-postgresql
-docker build -t local/space-agent:{tag} ./space-postgresql
+docker build -t local/space-agent:{tag} ./space-agent
 docker build -t local/space-upgrade:{tag} ./space-upgrade
 
 ```
@@ -137,9 +137,9 @@ Environment
 
 Source code download
 
-You can download the project as a whole through [xxx], or download this module's repository using the following command:
+You can download the project as a whole through [GitHub](https://github.com/ao-space/ao.space), or download this module's repository using the following command:
 
-- `git clone git@github.com:ao-space/space-aofs.git ./client-android`
+- `git clone git@github.com:ao-space/client-android.git ./client-android`
 
 Deploy
 
@@ -240,6 +240,4 @@ more docs refer to [AO.space Website](https://ao.space/en/docs/install-opensourc
 - Android support 5.0 and above
 - iOS supports 12.0 and above
 
-Please scan the QR code to install the client:
-
-![avatar](/assets/download_opensource.png)
+Please refer to the [download page](https://ao.space/download) to install the client.

--- a/docs/en/contribution-guidelines.md
+++ b/docs/en/contribution-guidelines.md
@@ -20,6 +20,10 @@ If you want to submit code to the project, you can do so by following these step
 - Perform tests to ensure that any changes have no impact.
 - Commit your changes and create a pull request.
 
+When working on documentation changes, you can run the local markdown link check to validate relative references:
+
+- `python3 scripts/check-doc-links.py`
+
 ### Code Quality
 
 We attach great importance to the quality of the code, so the code you submit should meet the following requirements:

--- a/scripts/check-doc-links.py
+++ b/scripts/check-doc-links.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+LINK_PATTERN = re.compile(r"\[[^]]+]\(([^)]+)\)")
+SKIP_PREFIXES = ("http://", "https://", "mailto:", "tel:")
+
+
+def iter_markdown_files(root: Path) -> list[Path]:
+    return [
+        root / "README.md",
+        root / "README_cn.md",
+        *sorted((root / "docs").rglob("*.md")),
+    ]
+
+
+def normalize_link(link: str) -> str:
+    link = link.strip()
+    if link.startswith("<") and link.endswith(">"):
+        link = link[1:-1].strip()
+    return link
+
+
+def resolve_target(doc_path: Path, link: str) -> Path:
+    link = link.split("#", 1)[0].split("?", 1)[0]
+    if not link:
+        return doc_path
+    return (doc_path.parent / link).resolve()
+
+
+def check_links(root: Path, markdown_files: list[Path]) -> list[str]:
+    errors: list[str] = []
+    for doc_path in markdown_files:
+        if not doc_path.exists():
+            continue
+        content = doc_path.read_text(encoding="utf-8")
+        for match in LINK_PATTERN.findall(content):
+            link = normalize_link(match)
+            if not link or link.startswith(SKIP_PREFIXES) or link.startswith("#"):
+                continue
+            if link.startswith("//"):
+                continue
+            target = resolve_target(doc_path, link)
+            if not target.exists():
+                errors.append(f"{doc_path.relative_to(root)} -> {link}")
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Check local markdown links.")
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path(__file__).resolve().parents[1],
+        help="Repository root directory.",
+    )
+    args = parser.parse_args()
+    root = args.root.resolve()
+    markdown_files = iter_markdown_files(root)
+    errors = check_links(root, markdown_files)
+    if errors:
+        print("Broken local markdown links detected:")
+        for error in sorted(errors):
+            print(f"- {error}")
+        return 1
+    print("All local markdown links look valid.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation

- Fix inaccurate and broken documentation instructions for building and downloading components and eliminate placeholder/typo content that caused broken local links.
- Add a small automated check to catch broken relative markdown links in the repo to prevent regressions.

### Description

- Corrected a README typo (`netrok` -> `network`) in `README.md` related to the network client description.
- Updated server build instructions to use the correct `./space-agent` build path and fixed Android client clone references in `docs/en/build-and-deploy.md` and `docs/cn/build-and-deploy.md` and replaced a placeholder `xxx` with a real GitHub link.
- Removed embedded QR image references and replaced them with download page references in both English and Chinese build docs.
- Added `scripts/check-doc-links.py` to validate local markdown links and documented its usage by adding `python3 scripts/check-doc-links.py` to `docs/en/contribution-guidelines.md`.

### Testing

- Ran `python3 scripts/check-doc-links.py` against the repository, which initially reported broken links such as `/assets/download_opensource.png` and `xxx` before the documentation fixes.
- Re-ran `python3 scripts/check-doc-links.py` after applying the fixes and it exited successfully with the message that all local markdown links look valid.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ca89b62e0832cb4fa9df60262f10f)